### PR TITLE
Include `modsettings.lsx` in VFS mappings

### DIFF
--- a/game_baldursgate3.py
+++ b/game_baldursgate3.py
@@ -110,6 +110,14 @@ class BaldursGate3Game(BasicGame, mobase.IPluginFileMapper):
                 )
                 map.append(m)
                 
+        map.append(
+            mobase.Mapping(
+                source = self._organizer.profile().absolutePath() + "/modsettings.lsx",
+                destination = self.GameDocumentsDirectory + "/modsettings.lsx",
+                is_directory = False,
+            )
+        )
+
         return map
 
     def _listDirsRecursive(self, dirs_list, prefix=""):


### PR DESCRIPTION
The `modsettings.lsx` file is being generated in the latest version, but it's not actually making it into `%LocalAppData%\Larian Studios\Baldur's Gate 3\PlayerProfiles\Public`. This PR adds a VFS mapping to fix that.